### PR TITLE
Fix dialyzer failure when missing an required dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 forecastr-*.tar
 
+# Do not include local PLT files
+.dialyzer/*.plt
+.dialyzer/*.hash
+


### PR DESCRIPTION
After cloning the repo and running `dialyzer` I got an error due to the missing path `.dialyzer/local.plt`. This should fix it.

```elixir
Copying dialyxir_erlang-20.2_elixir-1.6.3.plt to local.plt
** (File.CopyError) could not copy from "/home/tgrk/.mix/dialyxir_erlang-20.2_elixir-1.6.3.plt" to "/home/tgrk/Projects/personal/forecastr/.dialyzer/local.plt": no such file or directory
    (elixir) lib/file.ex:701: File.cp!/3
    lib/dialyxir/plt.ex:122: Dialyxir.Plt.check_beams/4
    lib/dialyxir/plt.ex:42: Dialyxir.Plt.check_plt/4
    (elixir) lib/enum.ex:1899: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/mix/tasks/dialyzer.ex:128: Mix.Tasks.Dialyzer.check_plt/0
    lib/mix/tasks/dialyzer.ex:101: Mix.Tasks.Dialyzer.run/1
    (mix) lib/mix/task.ex:314: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:80: Mix.CLI.run_task/2
...
```

Cheers! :slightly_smiling_face: 